### PR TITLE
商品削除機能＆出品者修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :move_to_index, only: [:edit]
-  before_action :set_destroy, only: [:destroy]
+  before_action :move_to_index, only: [:edit, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -33,6 +32,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   def show
@@ -53,13 +54,5 @@ class ItemsController < ApplicationController
     return if current_user.id == @item.user_id
 
     redirect_to action: :index
-  end
-
-  def set_destroy
-    if user_signed_in?
-      item = Item.find(params[:id])
-      item.destroy
-      redirect_to root_path
-    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update]
   before_action :authenticate_user!, except: [:index, :show]
   before_action :move_to_index, only: [:edit]
+  before_action :set_destroy, only: [:destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -32,9 +33,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    item.destroy
-    redirect_to root_path
   end
 
   def show
@@ -55,5 +53,13 @@ class ItemsController < ApplicationController
     return if current_user.id == @item.user_id
 
     redirect_to action: :index
+  end
+
+  def set_destroy
+    if user_signed_in?
+      item = Item.find(params[:id])
+      item.destroy
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,6 +31,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
+
   def show
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
         <% if @item.present? %>
           <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
@@ -43,7 +43,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user_id %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>


### PR DESCRIPTION
#What
商品削除機能＆出品者修正

#Why
商品削除機能の実装とレビュー依頼を行うため
また、出品者修正に関しては、表示をuser_idからuser.nicknameに変更した。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画：
https://gyazo.com/c85bbe1d8eb9cfb6def6a08649f5618f